### PR TITLE
[PR] Prevent Navigation Dropdown Menu from Showing on Mobile Login/Signup Screens

### DIFF
--- a/frontend/src/components/layout/Skeleton.jsx
+++ b/frontend/src/components/layout/Skeleton.jsx
@@ -101,8 +101,11 @@ function SidebarWithHeader({ children }) {
           </Drawer>
         )}
         {/* mobilenav */}
-        {isMobile && <MobileNav onOpen={onOpen} />}
-
+        {isMobile &&
+          location.pathname !== '/login' &&
+          location.pathname !== '/signup' &&
+          <MobileNav onOpen={onOpen} />
+        }
         <Box>{children}</Box>
       </>
     </Box>


### PR DESCRIPTION
Prevented the dropdown menu from appearing on mobile devices during the login and signup processes. This change ensures that users cannot access the profile, feed, or logout screens from the login or signup pages on mobile devices. It aligns the behavior with the desktop UI and enhances security by preventing unauthorized access.

**Closes #54.**